### PR TITLE
Improve header area on small screens

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -19,11 +19,11 @@ const Header = (props: Props) => {
           src="record.svg"
           style={{ width: 100, height: 100 }}
         />
-        <h1 style={{ fontSize: 42, fontFamily: "Rock Salt" }}>
+        <h1 className="text-4xl sm:text-5xl" style={{ fontFamily: "Rock Salt" }}>
           12inch.reviews
         </h1>
       </div>
-      <div className="p-4 md:p-0 m-auto sm:m-0">
+      <div className="py-8 md:p-0 m-auto sm:m-0">
         {!props.user && (
           <SpotifyLoginButton onClick={props.onSpotifyLoginClick} />
         )}


### PR DESCRIPTION
Not 1000% sure this is all good as I don't have it setup locally to test, but looks good in devtools testing. Only possible "negative" outcome I see is slightly larger H1 text at non-small-screen sizes; but that's so we can use classnames for sizing instead of direct `style` attribute, and thus use Tailwind's responsive goodies.

Before:
<img width="401" alt="image" src="https://user-images.githubusercontent.com/796639/66766270-f5d79080-ee6a-11e9-8d15-c74ae99379b1.png">

After:
<img width="410" alt="image" src="https://user-images.githubusercontent.com/796639/66766359-24556b80-ee6b-11e9-9fea-8e55e70fd3a2.png">
